### PR TITLE
DI-920 Changes for Medicover internal AF VCF

### DIFF
--- a/DI-435/README.md
+++ b/DI-435/README.md
@@ -8,14 +8,14 @@ This folder holds code to create an internal GRCh38 POP AF VCF [EBH-435](https:/
 ### Python script to find VCFs
 #### Usage
 Example command to find all CEN GRCh38 VCFs for all runs:
-```
+```bash
 python3 find_vcfs_to_merge.py \
     --assay "*CEN38" \
     --outfile_prefix CEN38 \
     --run_mode find_qc
 ```
 Example command to find TWE GRCh38 VCFs where the GRCh37 runs were between two dates:
-```
+```bash
 python3 find_vcfs_to_merge.py \
     --assay "*TWE38" \
     --outfile_prefix TWE38 \
@@ -25,7 +25,7 @@ python3 find_vcfs_to_merge.py \
 ```
 
 Example command to find Medicover VCFs with no QC status files:
-```
+```bash
 python3 find_vcfs_to_merge.py \
     --assay "*TWE38M" \
     --outfile_prefix TWE38M \
@@ -33,9 +33,11 @@ python3 find_vcfs_to_merge.py \
 ```
 
 #### Inputs
+
 - `-a --assay`: The GRCh38 project search term for in DNAnexus, e.g. `"*CEN38"`.
 - `-o --outfile_prefix`: Prefix to use to name the output files, e.g. `CEN38`.
 - `-r --run_mode`: A choice of whether to find and use QC status files (`find_qc`) or not (`no_qc`).
+
 In `find_qc` mode the following inputs are allowed:
   - `-s --start (optional)`: A date used to find DNAnexus (GRCh37) projects created after, see searching dates section below.
   - `-e --end (optional)`: A date used to find DNAnexus (GRCh37) projects created before, see searching dates section below.
@@ -56,7 +58,6 @@ How the script works in `find_qc` mode:
 - A CSV of all validation samples found (`{outfile_prefix}_validation_samples.csv`)
 - A CSV of all projects within search but missing QC file in DNAnexus and therefore not included (`{outfile_prefix}_projects_missing_QC.csv`).
 
-
 #### no_qc mode
 How the script works in `no_qc` mode:
 1. Finds all DNAnexus projects with suffix `--assay`
@@ -73,7 +74,7 @@ The bash script is run in a DNAnexus cloud workstation and requires positional i
 - The reference genome for GRCh38
 
 Example bash script command:
-```
+```bash
 bash merge_VCF_AF.sh \
     CEN38_files_to_merge.txt \
     GRCh38_GIABv3_no_alt_analysis_set_maskedGRC_decoys_MAP2K3_KMT2C_KCNJ18_noChr.fasta

--- a/DI-435/README.md
+++ b/DI-435/README.md
@@ -1,29 +1,41 @@
 ## Find and merge VCFs for creation of a 38 POP AF VCF
 
 ### Description
-This folder holds code to create an internal GRCh38 POP AF VCF based for [EBH-435](https://cuhbioinformatics.atlassian.net/browse/DI-435).
+This folder holds code to create an internal GRCh38 POP AF VCF [EBH-435](https://cuhbioinformatics.atlassian.net/browse/DI-435).
 
 ### Python script to find VCFs
 The Python script `find_vcfs_to_merge.py` takes inputs:
 - `-a --assay`: The project prefix to look for in DNAnexus, e.g. `"*CEN38"`
 - `-o --outfile_prefix`: What to name the output TSV file which lists VCF files to merge
+- `-r --run_mode`: A choice of whether to find QC status files ('find_qc') or not ('no_qc'). no_qc would be used as an input when searching Medicover projects
 - `-s --start (optional)`: A date used to find DNAnexus projects created after
 - `-e --end (optional)`: A date used to find DNAnexus projects created before
+- `-n --number_of_projects (optional)`: The number of most recent projects to keep
 
-Example Python script command:
-`python3 find_vcfs_to_merge.py --assay "*CEN38" --end 2024-05-03 --outfile_prefix CEN38`
+Example Python script command for CEN to find QC status files:
+`python3 find_vcfs_to_merge.py --assay "*CEN38" --end 2024-05-03 --outfile_prefix CEN38 --run_mode find_qc`
 
-Output:
-- A TSV listing the VCF files for all non-validation samples to merge (named by `{outfile_prefix}_files_to_merge.txt`)
-- A CSV of all validation samples found (`{outfile_prefix}_validation_samples.csv`)
+Example Python script command for Medicover:
+`python3 find_vcfs_to_merge.py --assay "*TWE38M"--outfile_prefix TWE38M --run_mode no_qc`
 
-How the script works:
-1. Finds all DNAnexus projects with suffix `--assay` and between `--start` and `--end` dates (if provided).
+How the script works in `find_qc` mode:
+1. Finds all DNAnexus projects with suffix `--assay` and between `--start` and `--end` dates (if provided) and then, if `--number_of_projects` is given, subsets this to the last n runs.
 2. Finds the related GRCh37 project for each of these projects and reads in all of the QC status files into one merged dataframe. If multiple QC status files exist in a project, the one created last is used.
 3. Finds all raw VCFs in each of the DNAnexus projects.
 4. Splits these VCFs into a list of validation (including control) samples and non-validation samples based on naming conventions
-5. Removes any samples which are duplicates or any which failed QC at any time based on information within the QC status files.
-6. Creates a final list of all VCFs to merge and writes this out to file with`--outfile_prefix`.
+5. Removes the first instance of a sample which is duplicated or any which failed QC at any time based on information within the QC status files.
+6. Creates a final list of all VCFs to merge and writes this out to file with `--outfile_prefix`.
+
+How the script works in `no_qc` mode:
+1. Finds all DNAnexus projects with suffix `--assay` and between `--start` and `--end` dates (if provided) and then, if `--number_of_projects` is given, subsets this to the last n runs.
+2. Finds all raw VCFs in each of the DNAnexus projects.
+3. Removes all samples which are duplicates.
+4. Creates a final list of all VCFs to merge and writes this to file with `--outfile_prefix`.
+
+Output:
+- A TSV listing the VCF files for all samples to merge (named by `{outfile_prefix}_files_to_merge.txt`)
+- If `--run_mode` is set to `find_qc`, a CSV of all validation samples found (`{outfile_prefix}_validation_samples.csv`)
+- If `--run_mode` is set to `no_qc`, a TXT file with all duplicate samples which have been removed (`{outfile_prefix}_all_dup_rows.txt`).
 
 ### Bash script to merge VCFs
 The bash script is run in a DNAnexus cloud workstation and requires positional inputs of:

--- a/DI-435/find_vcfs_to_merge.py
+++ b/DI-435/find_vcfs_to_merge.py
@@ -551,7 +551,9 @@ def main():
 
     else:
         all_sample_vcfs = find_vcf_files(b38_projects)
-        print(f"\nFound {len(all_sample_vcfs)} VCF files total")
+        print(
+            f"\nFound {len(all_sample_vcfs)} VCF files in GRCh38 projects"
+        )
 
         samples_df = pd.DataFrame(all_sample_vcfs)
         print(
@@ -565,9 +567,12 @@ def main():
         ].sort_values(by='sample')
         print(
             f"\nThere are {len(list(all_dups['sample'].unique()))} "
-            "samples which are duplicated")
+            "samples which have duplicate VCFs")
         all_dups.to_csv(
-            f"{args.outfile_prefix}_all_dup_rows.txt", index=False, sep='\t'
+            f"{args.outfile_prefix}_all_dups.txt",
+            index=False,
+            header=False,
+            sep='\t'
         )
 
         final_no_dups = samples_df.drop_duplicates(
@@ -577,7 +582,10 @@ def main():
             f"\nTotal non-duplicated samples to merge: {len(final_no_dups)}"
         )
         final_no_dups.to_csv(
-            f"{args.outfile_prefix}_files_to_merge.txt", index=False, sep='\t'
+            f"{args.outfile_prefix}_files_to_merge.txt",
+            index=False,
+            sep='\t',
+            header=False
         )
 
 

--- a/DI-435/find_vcfs_to_merge.py
+++ b/DI-435/find_vcfs_to_merge.py
@@ -510,43 +510,19 @@ def main():
             samples_df.duplicated(subset=['sample'], keep=False)
         ].sort_values(by='sample')
         print(
-            f"\nThere are {len(list(all_dups['sample'].unique()))} unique "
+            f"\nThere are {len(list(all_dups['sample'].unique()))} "
             "samples which are duplicated")
         all_dups.to_csv(
             f"{args.outfile_prefix}_all_dup_rows.txt", index=False, sep='\t'
         )
 
-        # Find duplicate samples within a run and write out to CSV
-        dups_by_run = samples_df[
-            samples_df.duplicated(subset=['sample', 'project'], keep=False)
-        ].sort_values(by='sample')
-        dups_by_run.to_csv(
-            f'{args.outfile_prefix}_dups_by_run.txt', index=False, sep='\t'
+        final_no_dups = samples_df.drop_duplicates(
+            subset=['sample'], keep=False
         )
         print(
-            f"\nThere are {len(list(dups_by_run['sample'].unique()))} samples "
-            "duplicated within a run"
+            f"\nTotal non-duplicated samples to merge: {len(final_no_dups)}"
         )
-
-        # Find duplicate samples across runs and write out to CSV
-        dups = samples_df.drop_duplicates()
-        mask = dups.duplicated(subset=['sample'], keep=False)
-        dups_across_projects = dups[mask].sort_values(by='sample')
-        dups_across_projects.to_csv(
-            f'{args.outfile_prefix}_dups_across_projects.txt',
-            index=False,
-            sep='\t'
-        )
-        print(
-            f"There are {len(list(dups_across_projects['sample'].unique()))} "
-            "samples duplicated across runs"
-        )
-
-        no_dups = samples_df.drop_duplicates(subset=['sample'], keep=False)
-        print(
-            f"\nTotal non-duplicated samples to merge: {len(no_dups)}"
-        )
-        no_dups.to_csv(
+        final_no_dups.to_csv(
             f"{args.outfile_prefix}_files_to_merge.txt", index=False, sep='\t'
         )
 

--- a/DI-435/find_vcfs_to_merge.py
+++ b/DI-435/find_vcfs_to_merge.py
@@ -126,7 +126,6 @@ def find_data(file_name, project_id):
             describe=True
         )
     )
-
     return files
 
 
@@ -265,7 +264,6 @@ def get_qc_files(b38_projects, start=None, end=None):
                 }
                 missing_projects.append(missing_project_info)
             all_qc_files.append(qc_file)
-
     print(len(all_qc_files), "QC files found in total")
     print(len(b37_projects), "b37 projects found in total")
 
@@ -449,6 +447,7 @@ def get_sample_types(projects):
                 non_validation_samples_in_run.append(
                     instrument_id + "-" + sample_id
                 )
+
             else:
                 all_validation_samples.append(
                     {

--- a/DI-435/find_vcfs_to_merge.py
+++ b/DI-435/find_vcfs_to_merge.py
@@ -551,7 +551,10 @@ def main():
 
         # Get list of non-failed non-validation samples to merge
         df_non_duplicated.to_csv(
-            f"{args.outfile_prefix}_files_to_merge.txt", sep="\t", header=False
+            f"{args.outfile_prefix}_files_to_merge.txt",
+            sep="\t",
+            header=False,
+            index=False
         )
         print("Number of final VCF files to merge:", len(df_non_duplicated))
 

--- a/DI-435/find_vcfs_to_merge.py
+++ b/DI-435/find_vcfs_to_merge.py
@@ -56,7 +56,7 @@ def parse_args() -> argparse.Namespace:
         help=(
             "Runmode - either 'find_qc' where QC status files are "
             "searched for and used to find failed samples, or 'no_qc'"
-            "where no QC status files are searched for"
+            " where no QC status files are searched for"
         )
     )
 
@@ -354,19 +354,20 @@ def get_failed_samples(qc_status_df):
 
 def find_medicover_vcf_files(projects):
     """
-    Find VCF files in a project
+    Find VCF files in specified projects
 
     Parameters
     ----------
-    project_id : str
-        DX project ID
+    projects : list
+        list of dicts, each with info about a DX project
 
     Returns
     -------
-    vcf_files : list
+    all_sample_vcfs : list
         list of dicts, each representing a VCF file in DX
     """
-    sub_remove = {
+    # Parts of filename we don't want in the sample name
+    strings_to_remove = {
         '_Wdh': '',
         '_Wdh2': '',
         '_Whd3': '',
@@ -376,11 +377,14 @@ def find_medicover_vcf_files(projects):
         vcf_files = find_data(
             "*_markdup_recalibrated_Haplotyper.vcf.gz", project['id']
         )
+        # Loop over VCFs in project, remove unwanted strings from filename
+        # Add info to a dict and append to our list
         for vcf_file in vcf_files:
             file_id = vcf_file["describe"]["id"]
             file_name = vcf_file["describe"]["name"]
-            sample_name = re.sub("|".join(
-                sub_remove), lambda x: sub_remove[x.group(0)],
+            sample_name = re.sub(
+                "|".join(strings_to_remove),
+                lambda x: strings_to_remove[x.group(0)],
                 file_name.split('-TwistWE')[0]
             )
 

--- a/DI-435/merge_VCF_AF.sh
+++ b/DI-435/merge_VCF_AF.sh
@@ -81,7 +81,6 @@ while IFS=$'\t' read -r _ field2 field3; do
 
 done < "$input_file"
 
-# Download VCFs in parallel
 echo "Downloading files"
 echo "${project_files[@]}" | tr ' ' '\n' | xargs -n 1 -P "${num_proc}" -I {} dx download --no-progress "{}"
 
@@ -97,7 +96,7 @@ find . -maxdepth 1 -name '*.vcf.gz' -print0 | xargs -0 -P "${num_proc}" -I{} bcf
 # Indexing normalised VCFs
 echo "Indexing normalised VCFs"
 cd norm || exit
-find . -maxdepth 1 -name '*.vcf.gz' -print0 | xargs -0 -P "${num_proc}" -I{} bcftools index -f "{}"
+echo *vcf.gz | tr ' ' '\n' | xargs -n 1 -P "${num_proc}" -I {} bcftools index -f "{}"
 
 # Merging normalised VCFs
 echo "Collating normalised VCFs"

--- a/DI-435/merge_VCF_AF.sh
+++ b/DI-435/merge_VCF_AF.sh
@@ -3,66 +3,87 @@
 #
 # Inputs:
 #   $1 -> input file with VCF files to merge
-#   $2 -> DNAnexus job ID for cloud workstation
-#   $3 -> Reference genome file
+#   $2 -> Reference genome file
 
 input_file=$1
-job=$2
-genome=$3
-project_file=$(awk -F ' ' '{print $3":"$4}' "$input_file")
-to_download=("$project_file")
+genome=$2
 
-# Download all vcfs
-for i in "${to_download[@]}"
-    do
-        echo "$i"
-        dx download "$i"
-    done
+set -exo pipefail
+
+exec 1> >(tee -a -i "/home/dnanexus/dx_stdout")
+exec 2> >(tee -a -i "/home/dnanexus/dx_stderr")
+
+# prefixes all lines of commands written to stdout with datetime
+PS4='\000[$(date)]\011'
+export TZ=Europe/London
+
+# set frequency of instance usage in logs to 10 seconds
+sudo kill $(ps aux | grep pcp-dstat | head -n1 | awk '{print $2}')
+/usr/bin/dx-dstat 10
+
+_get_peak_usage() {
+    : '''
+    Reports the peak memory and storage usage from dstat, to be called at end of app
+    '''
+    dx watch $DX_JOB_ID --no-follow --quiet > job.log
+
+    peak_mem=$(grep 'INFO CPU' job.log | cut -d':' -f5 | cut -d'/' -f1 | sort -n | tail -n1)
+    total_mem="$(($(grep MemTotal /proc/meminfo | grep --only-matching '[0-9]*')/1024))"
+
+    peak_storage=$(grep 'INFO CPU' job.log | cut -d':' -f6 | cut -d'/' -f1 | sort -n | tail -n1)
+    total_storage=$(df -Pk / | awk 'NR == 2' | awk '{printf("%.0f", $2/1024/1024)}')
+
+    echo "Memory usage peaked at ${peak_mem}/${total_mem}MB"
+    echo "Storage usage peaked at ${peak_storage}/${total_storage}GB"
+}
+
+
+# Download all VCFs in parallel
+echo "Downloading VCFs"
+to_download=$(awk -F ' ' '{print $2":"$3}' "$input_file")
+echo "$to_download" | tr ' ' '\n' | xargs -P8 -n1 -I{} dx download {} --no-progress
 
 # Index VCFs
 echo "Indexing VCFs"
-for vcf in ./*vcf.gz; do
-    bcftools index "$vcf";
-done
+find . -maxdepth 1 -name '*.vcf.gz' -print0 | xargs -0 -P8 -I{} bcftools index -f "{}"
 
-# Normalising VCFs
-mkdir norm
+# Normalise multiallelics and left align VCFs in parallel
 echo "Normalising VCFs"
-for vcf in ./*vcf.gz; do
-    bcftools norm -m -any -f "${genome}" -Oz "$vcf" > norm/"$vcf";
-done
+mkdir -p norm
+find . -maxdepth 1 -name '*.vcf.gz' -print0 | xargs -0 -P8 -I{} bcftools norm -m -any -f "${genome}" -Oz "{}" -o norm/"$(basename {})"
 
 # Indexing normalised VCFs
 echo "Indexing normalised VCFs"
 cd norm || exit
-for vcf in ./*vcf.gz; do
-    bcftools index -f "$vcf";
-done
+find . -maxdepth 1 -name '*.vcf.gz' -print0 | xargs -0 -P8 -I{} bcftools index -f "{}"
 
 # Merging normalised VCFs
 echo "Merging normalised VCFs"
+file_prefix="${input_file%.txt}"
 command="bcftools merge --output-type v -m none --missing-to-ref"
 # Add the VCF files names to the command
 for vcf in ./*vcf.gz; do
     command="${command} $vcf";
 done
-command="${command} > ../merged.vcf"
+command="${command} > ../${file_prefix}_merged.vcf"
 echo "${command}"
 eval "${command}"
 
 # Bgzip and index merged VCF file
-echo "Bgzip and indexing merged file"
+echo "Bgzipping and indexing merged file"
 cd ..
-bgzip merged.vcf
-bcftools index merged.vcf.gz
+bgzip "${file_prefix}_merged.vcf"
+bcftools index "${file_prefix}_merged.vcf.gz"
 
 # Final merging and processing
 echo "Final processing"
-command="bcftools norm -m -any -f ${genome} -Ou merged.vcf.gz"
-command="${command} | bcftools +fill-tags --output-type v -o merge_tag.vcf -- -t AN,AC,NS,AF,MAF,AC_Hom,AC_Het,AC_Hemi"
-command="${command} ; bcftools sort merge_tag.vcf -Oz > final_merged_${job}.vcf.gz"
-command="${command} ; tabix -p vcf final_merged_${job}.vcf.gz"
+command="bcftools norm -m -any -f ${genome} -Ou ${file_prefix}_merged.vcf.gz"
+command="${command} | bcftools +fill-tags --output-type v -o ${file_prefix}_merge_tag.vcf -- -t AN,AC,NS,AF,MAF,AC_Hom,AC_Het,AC_Hemi"
+command="${command} ; bcftools sort ${file_prefix}_merge_tag.vcf -Oz > final_merged_${file_prefix}.vcf.gz"
+command="${command} ; tabix -p vcf final_merged_${file_prefix}.vcf.gz"
 eval "$command"
-dx upload "final_merged_${job}.vcf.gz"
-dx upload "final_merged_${job}.vcf.gz.tbi"
-dx terminate "${job}"
+dx upload "final_merged_${file_prefix}.vcf.gz"
+dx upload "final_merged_${file_prefix}.vcf.gz.tbi"
+
+_get_peak_usage
+dx terminate "${DX_JOB_ID}"

--- a/DI-435/merge_VCF_AF.sh
+++ b/DI-435/merge_VCF_AF.sh
@@ -27,7 +27,7 @@ _get_peak_usage() {
     : '''
     Reports the peak memory and storage usage from dstat, to be called at end of script
     '''
-    dx watch $DX_JOB_ID --no-follow --quiet > job.log
+    dx watch "$DX_JOB_ID" --no-follow --quiet > job.log
 
     peak_mem=$(grep 'INFO CPU' job.log | cut -d':' -f5 | cut -d'/' -f1 | sort -n | tail -n1)
     total_mem="$(($(grep MemTotal /proc/meminfo | grep --only-matching '[0-9]*')/1024))"


### PR DESCRIPTION
- Add run mode choices where in mode 'no_qc' we can find Medicover VCFs and not find the QC status files in the GRCh37 project like we would for CEN or TWE
- Small changes to bash script to give better logging and check memory usage etc, use fields 2 and 3 of input file (since we longer output the pandas index from the Python file) and name output file by input file
- Update README for changes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/RD_requests/19)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new command-line argument `--run_mode` for the VCF merging script, allowing users to choose between `find_qc` and `no_qc` modes.
	- Added functionality to locate and process VCF files directly.
	- Enhanced logging and resource usage reporting in the merging script.

- **Documentation**
	- Updated README to clarify operational modes and provide example commands, improving user understanding of the scripts.

- **Bug Fixes**
	- Improved error handling and output messaging for project handling in the VCF processing script.

- **Chores**
	- Updated output file naming conventions for clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->