### PR TITLE
DI-1299 Check Dias somalier results in GRCh37 vs GRCh38

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 .env
 venv/
 __pycache__/
+!CEN_config.json
+!TWE_config.json

--- a/DI-1299/CEN_config.json
+++ b/DI-1299/CEN_config.json
@@ -1,0 +1,23 @@
+{
+    "assay": "CEN",
+    "search_term": "*CEN38",
+    "number_of_projects": null,
+    "filename": "Multiqc_somalier.samples.tsv",
+    "column_to_compare": "Predicted_Sex",
+    "sample_column": "sample_id",
+    "variables_to_plot": [
+        [
+            "X_n", "X_het", "X_hom_ref", "X_hom_alt", "X_depth_mean"
+        ],
+        [
+            "Y_n", "Y_depth_mean"
+        ],
+        [
+            "n_het", "n_hom_ref", "n_unknown", "n_hom_alt"
+        ],
+        [
+            "depth_mean", "depth_sd", "gt_depth_mean", "gt_depth_sd",
+            "ab_mean", "ab_std", "p_middling_ab"
+        ]
+    ]
+}

--- a/DI-1299/README.md
+++ b/DI-1299/README.md
@@ -1,4 +1,4 @@
-## Compare Somalier outputs in GRCh37 and GRCh38
+# Compare Somalier outputs in GRCh37 and GRCh38
 
 ### Description
 The `compare_b37_and_b38.py` script is used to compare Somalier Predicted_Sex values for samples in GRCh37 and GRCh38 and return any mismatches.

--- a/DI-1299/README.md
+++ b/DI-1299/README.md
@@ -1,9 +1,9 @@
 # Compare Somalier outputs in GRCh37 and GRCh38
 
-### Description
+## Description
 The `compare_b37_and_b38.py` script is used to compare Somalier Predicted_Sex values for samples in GRCh37 and GRCh38 and return any mismatches.
 
-### Inputs
+## Inputs
 - `--config (str)`: Path to a config file with relevant variables for the assay.
 
 Example config:
@@ -33,21 +33,21 @@ Example config:
 }
 ```
 
-### Running
+## Running
 Example command:
-```
+```bash
 python compare_b37_and_b38.py --config TWE_config.json
 ```
 
-### How it works
+## How it works
 The script:
 - Find all projects using the `search_term` in GRCh38 in DNAnexus.
 - Gets the related GRCh37 project for each GRCh38 project with the prefix `002_` and the suffix `_{assay}`.
- - Within the GRCh37 and GRCh38 projects, find all files by `filename` and reads them all in with pandas.
+  - Within the GRCh37 and GRCh38 projects, find all files by `filename` and reads them all in with pandas.
 - Identifies any mismatches in `column_to_compare` between the GRCh37 and GRCh38 values for each sample and investigate.
 - If mismatches are found, plots the variables in `variables_to_plot` to look at differences in these values for each sample between genome builds.
 
-### Output
+## Output
 - `{assay}_all_results.tsv`: A TSV with Somalier results for all samples found; headers have '_GRCh37' and '_GRCh38' suffixes to show which genome the result is from.
 - `{assay}_all_mismatches.tsv`: A TSV with all rows where there is a mismatch between the `column_to_compare` value in GRCh37 and GRCh38.
 - If there are samples with mismatches found, one plot is created for all metrics included in each nested list within `variables_to_plot` for each sample in GRCh37 and GRCh38. Each variable in each nested list is plotted as a scatter plot, one per row, and each plot is saved to HTML.

--- a/DI-1299/README.md
+++ b/DI-1299/README.md
@@ -1,0 +1,53 @@
+## Compare Somalier outputs in GRCh37 and GRCh38
+
+### Description
+The `compare_b37_and_b38.py` script is used to compare Somalier Predicted_Sex values for samples in GRCh37 and GRCh38 and return any mismatches.
+
+### Inputs
+- `--config (str)`: Path to a config file with relevant variables for the assay.
+
+Example config:
+```json
+{
+    "assay": "TWE",
+    "search_term": "*TWE38",
+    "number_of_projects": 10,
+    "filename": "Multiqc_somalier.samples.tsv",
+    "column_to_compare": "Predicted_Sex",
+    "sample_column": "sample_id",
+    "variables_to_plot": [
+        [
+            "X_n", "X_het", "X_hom_ref", "X_hom_alt", "X_depth_mean"
+        ],
+        [
+            "Y_n", "Y_depth_mean"
+        ],
+        [
+            "n_het", "n_hom_ref", "n_unknown", "n_hom_alt"
+        ],
+        [
+            "depth_mean", "depth_sd", "gt_depth_mean", "gt_depth_sd",
+            "ab_mean", "ab_std", "p_middling_ab"
+        ]
+    ]
+}
+```
+
+### Running
+Example command:
+```
+python compare_b37_and_b38.py --config TWE_config.json
+```
+
+### How it works
+The script:
+- Find all projects using the `search_term` in GRCh38 in DNAnexus.
+- Gets the related GRCh37 project for each GRCh38 project with the prefix `002_` and the suffix `_{assay}`.
+ - Within the GRCh37 and GRCh38 projects, find all files by `filename` and reads them all in with pandas.
+- Identifies any mismatches in `column_to_compare` between the GRCh37 and GRCh38 values for each sample and investigate.
+- If mismatches are found, plots the variables in `variables_to_plot` to look at differences in these values for each sample between genome builds.
+
+### Output
+- `{assay}_all_results.tsv`: A TSV with Somalier results for all samples found; headers have '_GRCh37' and '_GRCh38' suffixes to show which genome the result is from.
+- `{assay}_all_mismatches.tsv`: A TSV with all rows where there is a mismatch between the `column_to_compare` value in GRCh37 and GRCh38.
+- If there are samples with mismatches found, one plot is created for all metrics included in each nested list within `variables_to_plot` for each sample in GRCh37 and GRCh38. Each variable in each nested list is plotted as a scatter plot, one per row, and each plot is saved to HTML.

--- a/DI-1299/TWE_config.json
+++ b/DI-1299/TWE_config.json
@@ -1,0 +1,23 @@
+{
+    "assay": "TWE",
+    "search_term": "*TWE38",
+    "number_of_projects": null,
+    "filename": "Multiqc_somalier.samples.tsv",
+    "column_to_compare": "Predicted_Sex",
+    "sample_column": "sample_id",
+    "variables_to_plot": [
+        [
+            "X_n", "X_het", "X_hom_ref", "X_hom_alt", "X_depth_mean"
+        ],
+        [
+            "Y_n", "Y_depth_mean"
+        ],
+        [
+            "n_het", "n_hom_ref", "n_unknown", "n_hom_alt"
+        ],
+        [
+            "depth_mean", "depth_sd", "gt_depth_mean", "gt_depth_sd",
+            "ab_mean", "ab_std", "p_middling_ab"
+        ]
+    ]
+}

--- a/DI-1299/compare_b37_and_b38.py
+++ b/DI-1299/compare_b37_and_b38.py
@@ -1,0 +1,477 @@
+import argparse
+import json
+import re
+import sys
+from time import sleep
+
+import dxpy
+import pandas as pd
+import plotly.express as px
+
+
+def parse_args() -> argparse.Namespace:
+    """
+    Parse command line arguments
+
+    Returns
+    -------
+    args : Namespace
+        Namespace of passed command line argument inputs
+    """
+    parser = argparse.ArgumentParser(
+        description="Information required to find Somalier files"
+    )
+
+    parser.add_argument(
+        "-c",
+        "--config",
+        type=str,
+        required=True,
+        help="Path to the config file with variables to plot",
+    )
+
+    return parser.parse_args()
+
+
+def read_in_json(file_name):
+    """
+    Read in JSON file to a dict
+
+    Parameters
+    ----------
+    file_name : str
+        name of JSON file to read in
+
+    Returns
+    -------
+    json_dict : dict
+        the JSON converted to a Python dictionary
+    """
+    with open(file_name, "r", encoding="utf8") as json_file:
+        json_dict = json.load(json_file)
+
+    return json_dict
+
+
+def get_config_info(config_dict):
+    """
+    Get required keys from our config
+
+    Parameters
+    ----------
+    config_dict : dict
+        dict of JSON contents
+
+    Returns
+    -------
+    assay : str
+        The assay we're looking at
+    search_term : str
+        The search term to find projects in DX
+    number_of_projects : int (optional)
+        The number of projects to retrieve
+    filename : str
+        The name of the file to search for in the projects
+    column_to_compare : str
+        The column to compare between GRCh37 and GRCh38
+    sample_column : str
+        The column containing the sample IDs
+    variables_to_plot : list
+        List of lists of variables to plot
+    """
+    keys = [
+        "assay",
+        "search_term",
+        "number_of_projects",
+        "filename",
+        "column_to_compare",
+        "sample_column",
+        "variables_to_plot",
+    ]
+
+    (
+        assay,
+        search_term,
+        number_of_projects,
+        filename,
+        column_to_compare,
+        sample_column,
+        variables_to_plot,
+    ) = list(map(config_dict.get, keys))
+
+    return (
+        assay,
+        search_term,
+        number_of_projects,
+        filename,
+        column_to_compare,
+        sample_column,
+        variables_to_plot,
+    )
+
+
+def find_projects(search_term, number_of_projects=None):
+    """
+    Find projects in DNAnexus using specified search term
+
+    Parameters
+    ----------
+    search_term : str
+        term to use to search DNAnexus projects
+    number_of_projects : int, optional
+        number of projects to retrieve - obtains the last n projects by name,
+        default None
+
+    Returns
+    -------
+    projects : list
+        list of dicts, each representing a project
+    """
+    projects = list(
+        dxpy.find_projects(
+            name=search_term,
+            name_mode="glob",
+            describe={"fields": {"name": True}},
+        )
+    )
+    assert projects, f"No projects found with the search term {search_term}"
+    projects = sorted(projects, key=lambda x: x["describe"]["name"])
+
+    if number_of_projects is not None:
+        projects = projects[-int(number_of_projects) :]
+
+    return projects
+
+
+def find_files_in_project(search_term, project_id):
+    """
+    Find files in a DNAnexus project by name
+
+    Parameters
+    ----------
+    search_term : str
+        Term to use to find files
+    project_id : str
+        ID of the DX project to search in
+
+    Returns
+    -------
+    files : list
+        list of dicts, each representing a file in DNAnexus
+    """
+    files = list(
+        dxpy.find_data_objects(
+            project=project_id,
+            name=search_term,
+            name_mode="glob",
+            classname="file",
+            describe={"fields": {"name": True, "archivalState": True}},
+        )
+    )
+
+    return files
+
+
+def get_run_name_from_project_name(b38_project_name):
+    """
+    Extract the run name from a b38 project name
+
+    Parameters
+    ----------
+    b38_project_name : str
+        name of the GRCh38 project
+
+    Returns
+    -------
+    match.group(0) : str
+        name of the sequencing run
+    """
+    match = re.search(r"\d{6}_[A-Za-z0-9]+_\d{4}_[A-Z0-9]+", b38_project_name)
+    assert (
+        match
+    ), f"Error - no sequencing run name extracted from {b38_project_name}"
+
+    return match.group(0)
+
+
+def read_dnanexus_file_to_df(file_id, project_id):
+    """
+    Reads the contents of TSV to pandas DataFrame and add project column
+
+    Parameters
+    ----------
+    file_id : str
+        DNAnexus file ID of report to read
+    project_id : str
+        DNAnexus project id
+
+    Returns
+    -------
+    df : pd.DataFrame
+        Pandas df containing content of report
+    """
+    with dxpy.open_dxfile(file_id, project=project_id) as dx_file:
+        df = pd.read_csv(dx_file, sep="\t")
+    df["project"] = project_id
+
+    return df
+
+
+def unarchive_non_live_files(file_list):
+    """
+    Unarchive all non-live files and exit
+
+    Parameters
+    ----------
+    file_list : list
+        list of dicts, each with info about a file
+    """
+    non_live_files = [
+        file
+        for file in file_list
+        if file["describe"]["archivalState"] != "live"
+    ]
+
+    if non_live_files:
+        for non_live_file in non_live_files:
+            print(f"Requesting unarchiving for file {non_live_file['id']}")
+            file_object = dxpy.DXFile(
+                non_live_file["id"], project=non_live_file["project"]
+            )
+            file_object.unarchive()
+            sleep(5)
+        print("Exiting now. Please re-run once files are unarchived")
+        sys.exit()
+    else:
+        print("All files are live")
+
+
+def find_files_in_all_projects(b38_projects, filename, assay):
+    """
+    Find all files in GRCh37 and GRCh38 projects
+
+    Parameters
+    ----------
+    b38_projects : list
+        list of dicts, each with info about a DX GRCh38 project
+    filename : str
+        name of the file to search for in the projects
+    assay : str
+        the assay being investigated
+
+    Returns
+    -------
+    b37_files : list
+        list of dicts, each a file found in GRCh37
+    b38_files : list
+        list of dicts, each a file found in GRCh38
+    """
+    b37_files = []
+    b38_files = []
+    for proj in b38_projects:
+        b38_file = find_files_in_project(filename, proj["id"])
+        b38_files.extend(b38_file)
+        run_name = get_run_name_from_project_name(proj["describe"]["name"])
+        b37_project = find_projects(f"002_{run_name}_{assay}")
+        b37_file = find_files_in_project(filename, b37_project[0]["id"])
+        b37_files.extend(b37_file)
+
+    return b37_files, b38_files
+
+
+def read_in_b37_and_b38_files_and_merge(b38_files, b37_files):
+    """
+    Read in all GRCh37 files and all GRCh38 files to df then merge
+
+    Parameters
+    ----------
+    b38_files : list
+        list of dicts, each with info about a file in GRCh38
+    b37_files : list
+        list of dicts, each with info about a file in GRCh37
+
+    Returns
+    -------
+    final_df : pd.DataFrame
+        dataframe with results in GRCh38 and GRCh37 for each sample
+    """
+    all_b38_dfs = []
+    for file in b38_files:
+        all_b38_dfs.append(
+            read_dnanexus_file_to_df(file["id"], file["project"])
+        )
+    b38_df = pd.concat(all_b38_dfs, ignore_index=True)
+
+    all_b37_dfs = []
+    for file in b37_files:
+        all_b37_dfs.append(
+            read_dnanexus_file_to_df(file["id"], file["project"])
+        )
+    b37_df = pd.concat(all_b37_dfs, ignore_index=True)
+
+    all_results = pd.merge(
+        b37_df,
+        b38_df,
+        on="sample_id",
+        suffixes=("_GRCh37", "_GRCh38"),
+    )
+
+    # Reorder df so sample_id column is first + remove whitespace from headers
+    columns_to_sort = [
+        col for col in all_results.columns if col != "sample_id"
+    ]
+    reordered_df = all_results.reindex(
+        ["sample_id"] + sorted(columns_to_sort), axis=1
+    )
+    final_df = reordered_df.rename(columns=lambda x: x.strip())
+
+    return final_df
+
+
+def write_to_file(df, filename):
+    """
+    Write a pandas DataFrame to a TSV file
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame to write to file
+    filename : str
+        Name of the file to write to
+    """
+    df.to_csv(filename, sep="\t", index=False)
+
+
+def convert_mismatches_to_wide_format(mismatches, sample_column):
+    """
+    Convert df to wide format and melt so we can plot easily with Plotly
+    facets
+
+    Parameters
+    ----------
+    mismatches : pd.DataFrame
+        df with rows for any samples with mismatch in GRCh37 vs GRCh38
+    sample_column : str
+        name of the column containing sample IDs
+
+    Returns
+    -------
+    df_melted : pd.DataFrame
+        melted df with multiple rows per sample - all variables are in
+        'variable' column and all values are in 'value' column
+    """
+    col_stubnames = list(
+        set(
+            col.removesuffix("_GRCh37").removesuffix("_GRCh38").strip()
+            for col in mismatches.columns
+            if col != sample_column
+        )
+    )
+
+    wide_format = pd.wide_to_long(
+        mismatches,
+        i=sample_column,
+        j="Genome",
+        stubnames=col_stubnames,
+        suffix="_(GRCh37|GRCh38)",
+    ).reset_index()
+
+    wide_format["Genome"] = wide_format["Genome"].apply(
+        lambda s: s.removeprefix("_")
+    )
+
+    df_melted = wide_format.melt(
+        id_vars=[sample_column, "Genome"],
+        value_vars=col_stubnames,
+        var_name="variable",
+        value_name="value",
+    )
+
+    df_melted[sample_column] = (
+        df_melted[sample_column].str.split("-").str[:2].str.join("-")
+    )
+
+    return df_melted
+
+
+def create_and_save_scatter_plot(df, variable_set, file_name, sample_column):
+    """
+    Create and save a scatter plot for a given subset of variables.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Dataframe to plot
+    variable_set : list
+        List of variables to include in the plot.
+    file_name : str
+        The name of the file to save the plot to
+    sample_column : str
+        the name of the column with sample ID
+    """
+    plot_subset = df.loc[df["variable"].isin(variable_set)]
+    fig = px.scatter(
+        plot_subset,
+        x=sample_column,
+        y="value",
+        color="Genome",
+        facet_row="variable",
+    )
+    fig.update_yaxes(matches=None)
+    fig.update_xaxes(tickangle=45)
+    fig.write_html(file_name)
+
+
+def main():
+    args = parse_args()
+    config_dict = read_in_json(args.config)
+    (
+        assay,
+        search_term,
+        number_of_projects,
+        filename,
+        column_to_compare,
+        sample_column,
+        variables_to_plot,
+    ) = get_config_info(config_dict)
+    b38_projs = find_projects(search_term, number_of_projects)
+    print(f"Found {len(b38_projs)} {assay} GRCh38 projects:")
+    print("\n".join([proj["describe"]["name"] for proj in b38_projs]))
+
+    b37_files, b38_files = find_files_in_all_projects(
+        b38_projs, filename, assay
+    )
+    unarchive_non_live_files(b37_files + b38_files)
+
+    merged_df = read_in_b37_and_b38_files_and_merge(b38_files, b37_files)
+    write_to_file(merged_df, f"{assay}_all_results.tsv")
+    print(f"There are {len(merged_df)} samples found for {assay}")
+
+    mismatches = merged_df.query(
+        f"{column_to_compare}_GRCh37 != {column_to_compare}_GRCh38"
+    )
+
+    print(
+        f"There are {len(mismatches)} samples with mismatches in"
+        f" {column_to_compare} between GRCh37 and GRCh38"
+    )
+    write_to_file(mismatches, f"{assay}_all_mismatches.tsv")
+
+    if not mismatches.empty:
+        mismatches_wide = convert_mismatches_to_wide_format(
+            mismatches, sample_column
+        )
+        if variables_to_plot:
+            for index, variable_list in enumerate(variables_to_plot):
+                create_and_save_scatter_plot(
+                    mismatches_wide,
+                    variable_list,
+                    f"{assay}_discrepancies_{index}.html",
+                    sample_column,
+                )
+        else:
+            print("No variables to plot in config file")
+
+
+if __name__ == "__main__":
+    main()

--- a/DI-1299/compare_b37_and_b38.py
+++ b/DI-1299/compare_b37_and_b38.py
@@ -89,25 +89,7 @@ def get_config_info(config_dict):
         "variables_to_plot",
     ]
 
-    (
-        assay,
-        search_term,
-        number_of_projects,
-        filename,
-        column_to_compare,
-        sample_column,
-        variables_to_plot,
-    ) = list(map(config_dict.get, keys))
-
-    return (
-        assay,
-        search_term,
-        number_of_projects,
-        filename,
-        column_to_compare,
-        sample_column,
-        variables_to_plot,
-    )
+    return list(map(config_dict.get, keys))
 
 
 def find_projects(search_term, number_of_projects=None):

--- a/DI-1299/compare_b37_and_b38.py
+++ b/DI-1299/compare_b37_and_b38.py
@@ -134,7 +134,10 @@ def find_projects(search_term, number_of_projects=None):
             describe={"fields": {"name": True}},
         )
     )
-    assert projects, f"No projects found with the search term {search_term}"
+    if not projects:
+        raise ValueError(
+            f"No projects found with the search term {search_term}"
+        )
     projects = sorted(projects, key=lambda x: x["describe"]["name"])
 
     if number_of_projects is not None:
@@ -187,9 +190,10 @@ def get_run_name_from_project_name(b38_project_name):
         name of the sequencing run
     """
     match = re.search(r"\d{6}_[A-Za-z0-9]+_\d{4}_[A-Z0-9]+", b38_project_name)
-    assert (
-        match
-    ), f"Error - no sequencing run name extracted from {b38_project_name}"
+    if not match:
+        raise ValueError(
+            f"Error - no sequencing run name extracted from {b38_project_name}"
+        )
 
     return match.group(0)
 

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@ Repository for code related to small tasks for supporting the RD service.
 
 |  Ticket   |   Summary   |
 |   ---     |     ---     |
-| [EBH-3050] | Determine how many workbooks were released/not released (based on number of variants filtered) per clinical indication since new filtering introduced
-| [DI-773] | Gather and plot QC metrics
-| [DI-1057] | Validate East GLH RD Test Directory hosted on AWS RDS
-| [DI-1094] | CEN/WES GRCh38 egg_sex_check thresholds - August 2024
-| [DI-1189] | Create new PanelApp JSON file
-| [DI-435] | Find and merge VCFs for creation of a GRCh38 POP AF VCF
-| [DI-1294] | Remove any content from the PID fields in workbooks in a given path
-| [DI-1299] | Compare values between GRCh37 and GRCh38 for Somalier
+| [EBH-3050] | Determine how many workbooks were released/not released (based on number of variants filtered) per clinical indication since new filtering introduced |
+| [DI-773] | Gather and plot QC metrics |
+| [DI-1057] | Validate East GLH RD Test Directory hosted on AWS RDS |
+| [DI-1094] | CEN/WES GRCh38 egg_sex_check thresholds - August 2024 |
+| [DI-1189] | Create new PanelApp JSON file |
+| [DI-435] | Find and merge VCFs for creation of a GRCh38 POP AF VCF |
+| [DI-1294] | Remove any content from the PID fields in workbooks in a given path |
+| [DI-1299] | Compare values between GRCh37 and GRCh38 for Somalier |
 
 
 [EBH-3050]: https://cuhbioinformatics.atlassian.net/browse/EBH-3050
@@ -19,5 +19,5 @@ Repository for code related to small tasks for supporting the RD service.
 [DI-1094]: https://cuhbioinformatics.atlassian.net/browse/DI-1094
 [DI-1189]: https://cuhbioinformatics.atlassian.net/browse/DI-1189
 [DI-435]: https://cuhbioinformatics.atlassian.net/browse/DI-435
-[DI-1294]: https://cuhbioinformatics.atlassian.net/issues/DI-1294
+[DI-1294]: https://cuhbioinformatics.atlassian.net/browse/DI-1294
 [DI-1299]: https://cuhbioinformatics.atlassian.net/browse/DI-1299

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Repository for code related to small tasks for supporting the RD service.
 | [DI-1189] | Create new PanelApp JSON file
 | [DI-435] | Find and merge VCFs for creation of a GRCh38 POP AF VCF
 | [DI-1294] | Remove any content from the PID fields in workbooks in a given path
+| [DI-1299] | Compare values between GRCh37 and GRCh38 for Somalier
 
 
 [EBH-3050]: https://cuhbioinformatics.atlassian.net/browse/EBH-3050
@@ -19,3 +20,4 @@ Repository for code related to small tasks for supporting the RD service.
 [DI-1189]: https://cuhbioinformatics.atlassian.net/browse/DI-1189
 [DI-435]: https://cuhbioinformatics.atlassian.net/browse/DI-435
 [DI-1294]: https://cuhbioinformatics.atlassian.net/issues/DI-1294
+[DI-1299]: https://cuhbioinformatics.atlassian.net/browse/DI-1299


### PR DESCRIPTION
- Add Python script to find and read in `Multiqc_somalier.samples.tsv` files in GRCh37 and GRCh38 and find any samples with mismatches for `Predicted_Sex` between genome builds
- Add config files given as input to script for TWE and CEN
- Add README for script
- Update repo README for this request

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/RD_requests/22)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced two new configuration files for assay parameters.
	- Added a new script for comparing genomic data between GRCh37 and GRCh38.
	- Updated the `README.md` with a new section detailing the comparison script and its functionality.

- **Documentation**
	- Enhanced `README.md` with details on the new script and configuration files.
	- Added a new entry for ticket [DI-1299] in the ticket summary table of `README.md`.
	- Updated the link for ticket [DI-1294] in `README.md`.

- **Bug Fixes**
	- Updated `.gitignore` to ensure specific configuration files are not ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[DI-1299]: https://cuhbioinformatics.atlassian.net/browse/DI-1299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ