### PR TITLE
First commit for DI-1141 scripts

### DIFF
--- a/DI-1141/compare_validator_vcf.py
+++ b/DI-1141/compare_validator_vcf.py
@@ -1,0 +1,183 @@
+import pandas as pd
+import argparse
+import plotly.express as px
+
+def read_file(mismatches_tsv, variant_validator_batch):
+    '''
+    Read mismatches tsv from compare_vcf_hgvs script and VariantValidator batch output.
+    '''
+    mismatches_df = pd.read_csv(
+        mismatches_tsv,
+        sep='\t'
+    )
+    
+    vv_batch_df = pd.read_csv(
+        variant_validator_batch,
+        header=2,
+        sep='\t',
+        usecols=['Input', 'HGVS_transcript', 'HGVS_Predicted_Protein']
+    )
+    vv_batch_df.columns=["Variant", "HGVSc_validator", "HGVSp_validator"]
+
+    return mismatches_df, vv_batch_df
+
+
+def parse_validator_batch(vv_batch_df):
+    '''
+    Extract the relevant information from the VariantValidator batch output and reformat
+    to similar format as any_mismatches.tsv
+    '''
+    # get only Feature column
+    vv_batch_df['Feature'] = vv_batch_df['HGVSc_validator'].str.split(':').str[0]
+
+    # split variant output back to CHROM, POS, REF, ALT
+    variant_split = vv_batch_df["Variant"].str.split("-", expand=True)
+    variant_split.columns=["CHROM", "POS", "REF", "ALT"]
+
+    # concat them
+    batch_reformatted = pd.concat([variant_split, vv_batch_df.drop(columns=["Variant"])], axis=1)
+    batch_reformatted['POS'] = batch_reformatted['POS'].astype(str).astype(int)
+
+    return batch_reformatted
+
+
+def merge_mismatches_batch(mismatches_df, vv_batch):
+    '''
+    Merge any_mismatches df with the parsed and reformatted VariantValidator batch df
+    '''
+    validator_merged = pd.merge(mismatches_df, vv_batch, on=["CHROM", "POS", "REF", "ALT", "Feature"], how='inner')
+
+    return validator_merged
+
+
+def convention_changes(validator_merged):
+    '''
+    Changing the convention of the merged df because the output of VariantValidator differs to the output of VEP
+    '''
+    # if ends with p.? set to .
+    validator_merged.loc[validator_merged["HGVSp_validator"].str.endswith("p.?"), "HGVSp_validator"] = "."
+
+    # remove brackets from HGVSp validator
+    validator_merged["HGVSp_validator"] = validator_merged["HGVSp_validator"].str.replace(r"[()]", "", regex=True)
+
+    # covert = in HGVSp to %3D
+    validator_merged["HGVSp_validator"] = validator_merged["HGVSp_validator"].str.replace("=", "%3D")
+
+    return validator_merged
+
+
+def find_vep_validator_mismatches(merged_df, old_version, new_version):
+    '''
+    Compare HGVSc and HGVSp for each VEP version with VariantValidator batch output
+    '''
+    merged_df["HGVSc_" + old_version + "_mismatch"] = merged_df["HGVSc_" + old_version] != merged_df["HGVSc_validator"]
+    merged_df["HGVSc_" + new_version + "_mismatch"] = merged_df["HGVSc_" + new_version] != merged_df["HGVSc_validator"]
+    merged_df["HGVSp_" + old_version + "_mismatch"] = merged_df["HGVSp_" + old_version] != merged_df["HGVSp_validator"]
+    merged_df["HGVSp_" + new_version + "_mismatch"] = merged_df["HGVSp_" + new_version] != merged_df["HGVSp_validator"]
+    merged_df["HGVSc_both_mismatch"] = merged_df["HGVSc_" + old_version + "_mismatch"] & merged_df["HGVSc_" + new_version + "_mismatch"]
+    merged_df["HGVSp_both_mismatch"] = merged_df["HGVSp_" + old_version + "_mismatch"] & merged_df["HGVSp_" + new_version + "_mismatch"]
+
+    mismatch_df = merged_df[[
+    "HGVSc_" + old_version + "_mismatch",
+    "HGVSc_" + new_version + "_mismatch",
+    "HGVSc_both_mismatch",
+    "HGVSp_" + old_version + "_mismatch",
+    "HGVSp_" + new_version + "_mismatch",
+    "HGVSp_both_mismatch"
+    ]].sum().reset_index()
+    mismatch_df.columns = ["Mismatch_Type", "Count"]
+
+    mismatches_fig = px.bar(
+        mismatch_df,
+        x="Mismatch_Type",
+        y="Count",
+        title="Mismatch Counts",
+    )
+
+    mismatches_fig.write_image("mismatches_fig.png")
+
+
+def find_new_changes(merged_df, old_version, new_version):
+    '''
+    Find newly wrong and newly corrected changes
+    '''
+    # Newly corrected in v113
+    merged_df["HGVSc_newly_corrected"] = (merged_df["HGVSc_" + old_version + "_mismatch"] == True) & (merged_df["HGVSc_" + new_version + "_mismatch"] == False)
+    merged_df["HGVSp_newly_corrected"] = (merged_df["HGVSp_" + old_version + "_mismatch"] == True) & (merged_df["HGVSp_" + new_version + "_mismatch"] == False)
+
+    # Newly wrong in v113
+    merged_df["HGVSc_newly_wrong"] = (merged_df["HGVSc_" + old_version + "_mismatch"] == False) & (merged_df["HGVSc_" + new_version + "_mismatch"] == True)
+    merged_df['HGVSp_newly_wrong'] = (merged_df["HGVSp_" + old_version + "_mismatch"] == False) & (merged_df["HGVSp_" + new_version + "_mismatch"] == True)
+
+    # Get counts
+    between_version_counts = merged_df[[
+        "HGVSc_newly_wrong",
+        "HGVSp_newly_wrong",
+        "HGVSc_newly_corrected",
+        "HGVSp_newly_corrected"
+    ]].sum().reset_index()
+    between_version_counts.columns = ["Mismatch_Type", "Count"]
+
+    # Write to files
+    merged_df.loc[merged_df['HGVSc_newly_wrong'] == True].to_csv('hgvsc_newly_wrong.tsv', sep='\t', index=False)
+    merged_df.loc[merged_df['HGVSp_newly_wrong'] == True].to_csv('hgvsp_newly_wrong.tsv', sep='\t', index=False)
+    merged_df[merged_df['HGVSc_newly_corrected'] == True].to_csv('hgvsc_newly_corrected.tsv', sep='\t', index=False)
+    merged_df[merged_df['HGVSp_newly_corrected'] == True].to_csv('hgvsp_newly_corrected.tsv', sep='\t', index=False)
+
+    # Plot
+    changes_fig = px.bar(
+        between_version_counts,
+        x="Mismatch_Type",
+        y="Count",
+        title="Mismatch Counts",
+    )
+
+    changes_fig.write_image("new_changes_fig.png")
+
+
+def parse_args() -> argparse.Namespace:
+    """
+    Parse command line arguments
+
+    Returns
+    ----------
+    args : Namespace
+        Namespace of passed command line argument inputs
+    """
+    parser = argparse.ArgumentParser(
+        description="Python script comparing any mismatches in HGVSc, HGVSp, or Consequence between 2 VEP versions produced by compare_vcf_hgvs.py script"
+    )
+
+    parser.add_argument(
+        '-tsv', '--mismatches_tsv', type=str, help="full path of tsv output of compare_vcf_hgvs script (any_mismatches.tsv)"
+    )
+    parser.add_argument(
+        '-vv', '--variant_validator', type=str, help="full path of VariantValidator batch job txt file"
+    )
+    parser.add_argument(
+        '-old', '--old_version', type=str, help="Old VEP version"
+    )
+    parser.add_argument(
+        '-new', '--new_version', type=str, help="New VEP version"
+    )
+    args = parser.parse_args()
+
+    return args
+
+
+def main():
+    args = parse_args()
+
+    mismatches_df, vv_batch_df = read_file(args.mismatches_tsv, args.variant_validator)
+    parsed_vv_batch = parse_validator_batch(vv_batch_df)
+    validator_merged = merge_mismatches_batch(parsed_vv_batch, mismatches_df)
+    merged_df = convention_changes(validator_merged)
+
+    merged_df.to_csv('merged_validator_mismatches.tsv', sep='\t', header=True, index=False)
+
+    find_vep_validator_mismatches(merged_df, args.old_version, args.new_version)
+    find_new_changes(merged_df, args.old_version, args.new_version)
+
+
+if __name__ == "__main__":
+    main()

--- a/DI-1141/compare_vcf_hgvs.py
+++ b/DI-1141/compare_vcf_hgvs.py
@@ -1,0 +1,144 @@
+import pandas as pd
+import argparse
+import sys
+import os
+import re
+import numpy as np
+
+def get_sample_pairs(directory):
+    '''
+    Read sample pairs in directory.
+    '''
+    files = sorted(f for f in os.listdir(directory) if f.endswith("_filtered.vcf"))
+    sample_ids = {}
+
+    # find files with regex pattern and group
+    for file in files:
+        match = re.match(r"^(\d{9}-\d{5}[A-Z]\d{4})-.*_vep(\d+)\_filtered.vcf$", file) 
+        if match:
+            sample_name = match.group(1)
+            sample_ids.setdefault(sample_name, []).append(file)
+
+    # make sure 2 versions (old and new vep) per sample
+    sample_pairs = [(files[0], files[1]) for sample, files in sample_ids.items() if len(files) == 2]
+    
+    return sample_pairs
+
+
+def read_file(old_vcf, new_vcf, old_version, new_version, directory):
+    '''
+    Read old and new VEP version VCFs into pandas dataframes.
+    '''
+    old_vep_file = os.path.join(directory, old_vcf)
+    new_vep_file = os.path.join(directory, new_vcf)
+
+    annotations_old = pd.read_csv(
+        old_vep_file,
+        sep='\t',
+        names=["CHROM", "POS", "REF", "ALT", "Consequence_" + old_version, "Feature", "HGVSc_" + old_version, "HGVSp_" + old_version],
+        dtype={'CHROM': 'str'}
+    )
+    
+    annotations_new = pd.read_csv(
+        new_vep_file,
+        sep='\t',
+        names=["CHROM", "POS", "REF", "ALT", "Consequence_" + new_version, "Feature", "HGVSc_" + new_version, "HGVSp_" + new_version],
+        dtype={'CHROM': 'str'}
+    )
+
+    return annotations_old, annotations_new
+
+
+def find_mismatches(annotations_old, annotations_new, old_version, new_version):
+    '''
+    Merge old and new variant lines on variant and feature.
+    Find lines where Consequence, HGVSc, or HGVSp don't match between old and new.
+    Remove NR transcripts.
+    '''
+    # merge based on certain headers
+    merged = pd.merge(annotations_old, annotations_new, on=["CHROM", "POS", "REF", "ALT", "Feature"], how='inner')
+    
+    # get any mismatches between old and new Consequence, HGVSc, and HGVSp
+    any_mismatches = merged[(merged['Consequence_' + old_version] != merged['Consequence_' + new_version]) 
+                            | (merged['HGVSc_' + old_version] != merged['HGVSc_' + new_version]) 
+                            | (merged['HGVSp_' + old_version] != merged['HGVSp_' + new_version])]
+    
+    # drop any NR transcripts
+    mismatches_not_nr = any_mismatches[~any_mismatches['Feature'].str.startswith('NR_')]
+
+    return mismatches_not_nr
+
+
+def to_csv_chunks(df, output_file, sep=",", chunksize=25000):
+    '''
+    Save pandas dataframe to csv with max 25000 rows. If there are more than 25000 rows,
+    create files with similar number of rows.
+    '''
+    total_rows = len(df)
+    num_csv = (total_rows // chunksize) + (1 if total_rows % chunksize else 0)
+
+    for i, chunk in enumerate(np.array_split(df, num_csv)):
+        chunk.to_csv(f"{output_file}_{i}.txt", sep=sep, index=False, header=False)
+
+
+def create_variantvalidator_inputs(all_dfs):
+    '''
+    Get unique variants and transcripts for VariantValidator input. Split to 25000 variant per file.
+    '''
+    # get unique variants
+    chr_pos_ref_alt = all_dfs[['CHROM','POS', 'REF', 'ALT']]
+    uniq_vars = chr_pos_ref_alt.drop_duplicates()
+    to_csv_chunks(uniq_vars, "unique_variants", "-")
+
+    # get unique transcripts
+    transcript_only = all_dfs[['Feature']]
+    uniq_transcripts = transcript_only.drop_duplicates()
+    to_csv_chunks(uniq_transcripts, "unique_transcripts")
+
+
+def parse_args() -> argparse.Namespace:
+    """
+    Parse command line arguments
+
+    Returns
+    ----------
+    args : Namespace
+        Namespace of passed command line argument inputs
+    """
+    parser = argparse.ArgumentParser(
+        description="Python script comparing VCFs with different vep versions"
+    )
+
+    parser.add_argument(
+        '-dir', '--directory', type=str, help="Directory that contains all VCFs"
+    )
+    parser.add_argument(
+        '-old', '--old_version', type=str, help="Old VEP version"
+    )
+    parser.add_argument(
+        '-new', '--new_version', type=str, help="New VEP version"
+    )
+    args = parser.parse_args()
+
+    return args
+
+
+def main():
+    args = parse_args()
+
+    vcf_pairs = get_sample_pairs(args.directory)
+    all_dfs=[]
+
+    for old_vcf,new_vcf in vcf_pairs:
+        annotations_old, annotations_new = read_file(old_vcf, new_vcf, args.old_version, args.new_version, args.directory)
+        all_dfs.append(find_mismatches(annotations_old, annotations_new, args.old_version, args.new_version))
+    
+    all_dfs = pd.concat(all_dfs)
+    all_dfs = all_dfs.drop_duplicates()
+    all_dfs.to_csv('any_mismatches.tsv', sep='\t', header=True, index=False)
+    
+    create_variantvalidator_inputs(all_dfs)
+
+
+if __name__ == "__main__":
+    main()

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Repository for code related to small tasks for supporting the RD service.
 | [DI-435] | Find and merge VCFs for creation of a GRCh38 POP AF VCF |
 | [DI-1294] | Remove any content from the PID fields in workbooks in a given path |
 | [DI-1299] | Compare values between GRCh37 and GRCh38 for Somalier |
+| [DI-1141] | Compare Consequence, HGVSc, and HGVSp values between VEP versions and compare with output batch of VariantValidator |
 
 
 [EBH-3338]: https://cuhbioinformatics.atlassian.net/browse/EBH-3338
@@ -23,3 +24,4 @@ Repository for code related to small tasks for supporting the RD service.
 [DI-435]: https://cuhbioinformatics.atlassian.net/browse/DI-435
 [DI-1294]: https://cuhbioinformatics.atlassian.net/browse/DI-1294
 [DI-1299]: https://cuhbioinformatics.atlassian.net/browse/DI-1299
+[DI-1141]: https://cuhbioinformatics.atlassian.net/browse/DI-1141


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/RD_requests/24)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a command-line tool that compares genomic variant annotations between VEP versions, providing visual summaries and detailed reports of discrepancies.
	- Added a utility to compare variant call files across different VEP versions by grouping sample pairs, identifying mismatches, and generating manageable output files for large datasets.
	- Updated the documentation to include a new task related to comparing Consequence, HGVSc, and HGVSp values between VEP versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->