### PR TITLE
Update medicover.py

### DIFF
--- a/EBH-3338/medicover.py
+++ b/EBH-3338/medicover.py
@@ -113,7 +113,10 @@ def main():
     samples_with_json.to_csv(outfile_with_json, sep="\t", index=False)
 
     samples_with_json_in_json_missing = samples_with_json[
-        samples_with_json.json_folder_path.str.contains("JSON_MISSING")]
+        samples_with_json.json_folder_path.str.contains(
+            "JSON_MISSING|json_missing", regex=True
+        )
+    ]
 
     print(
         f"Found {len(samples_with_json_in_json_missing)} Medicover samples "


### PR DESCRIPTION
Change it so that folder paths "json_missing" in both full lower changes or upper case are identified as samples with json in a json_missing folder.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/RD_requests/27)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the detection process for missing JSON files by supporting case-insensitive matching. This improvement ensures that all relevant instances are identified correctly, leading to more accurate data reporting to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->